### PR TITLE
Add insertId to event payload

### DIFF
--- a/db.js
+++ b/db.js
@@ -13,10 +13,10 @@ var DataBase = function() {
   this.conn = BigQuery(config);
 };
 
-DataBase.prototype.insertInto = function(table, rows) {
+DataBase.prototype.insertInto = function(table, rows, options) {
   var table = this.conn.dataset(ds).table(table);
 
-  table.insert(rows, function (err, insertErrors, apiResponse) {
+  table.insert(rows, (options || {}), function (err, insertErrors, apiResponse) {
     if (err) {
       return console.log('Error while inserting data: %s', err);
     }

--- a/formatter.js
+++ b/formatter.js
@@ -19,7 +19,7 @@ Formatter.event = (rawData) => {
   });
 
   return {
-    insertId: FIELDS['event_id'],
+    insertId: result['event_id'],
     json: result
   };
 };

--- a/formatter.js
+++ b/formatter.js
@@ -5,7 +5,7 @@ var Formatter = function() {
 
 };
 
-Formatter.event  = (rawData) => {
+Formatter.event = (rawData) => {
   var content = rawData.split('\t'),
       result = {};
   var counter = 0;
@@ -18,14 +18,18 @@ Formatter.event  = (rawData) => {
     }
   });
 
-  return result;
+  return {
+    insertId: FIELDS['event_id'],
+    json: result
+  };
 };
 
 Formatter.contexts = (evt) => {
-  var contexts = JSON.parse(evt['contexts'])['data'];
+  var evtPayload = evt['json'],
+      contexts = JSON.parse(evtPayload['contexts'])['data'];
 
-  if(evt['unstruct_event'] !== null) {
-    contexts.push(JSON.parse(evt['unstruct_event'])['data']);
+  if(evtPayload['unstruct_event'] !== null) {
+    contexts.push(JSON.parse(evtPayload['unstruct_event'])['data']);
   }
 
   var result = {};
@@ -43,8 +47,8 @@ Formatter.contexts = (evt) => {
       "schema_name" : schemaInfo[1],
       "schema_format" : schemaInfo[2],
       "schema_version" : schemaInfo[3],
-      "root_id" : evt['event_id'],
-      "root_tstamp" : evt['collector_tstamp'],
+      "root_id" : evtPayload['event_id'],
+      "root_tstamp" : evtPayload['collector_tstamp'],
       "ref_root" : "events",
       "ref_tree" : ['events', schemaInfo[1]], // FIXME: remove this tree build hardcoded
       "ref_parent" : 'events',

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ exports.handler = (event, context, callback) => {
   event.Records.forEach((record) => {
     const payload = new Buffer(record.kinesis.data, 'base64').toString();
     const event = Formatter.event(payload),
-          contexts = Formatter.contexts_(event);
+          contexts = Formatter.contexts(event);
 
     Object.keys(contexts).forEach((c) => {
       var key = DataBase.toTableName(c);
@@ -27,7 +27,7 @@ exports.handler = (event, context, callback) => {
     events.push(event);
   });
 
-  db.insertInto('events', events);
+  db.insertInto('events', events, { raw: true });
 
   db.tables(function(tables) {
     Object.keys(nestedData).forEach((table) => {


### PR DESCRIPTION
This is necessary to avoid duplicated events in bigquery database.

> To help ensure data consistency, you can supply insertId for each inserted row. BigQuery remembers this ID for at least one minute. If you try to stream the same set of rows within that time period and the insertId property is set, BigQuery uses the insertId property to de-duplicate your data on a best effort basis.

**Important:** BigQuery stores this ID for one minute. If another event is sent with the same ID more than one minute later, it will be inserted.

```sql
SELECT event_id, COUNT(*) AS total
FROM atomic.events
GROUP BY event_id
HAVING COUNT(*) > 1
ORDER BY total DESC;
```