### PR TITLE
Partition time

### DIFF
--- a/bigquery.js
+++ b/bigquery.js
@@ -18,10 +18,9 @@ var BigQuery = function() {
 BigQuery.prototype.insertInto = function(tableName, rows, options) {
   //Here I should get the table based on name
   // and insert in the right partition whenever the table is partitioned
-  var me = this;
   rows.forEach((row) => {
     // First, we get the table object with all available information
-    me.table(tableName, function(err, table) {
+    this.table(tableName, function(err, table) {
       if (err) {
         console.log(`Sorry! We've got an error while fetching the table ${tableName}.\nERROR: ${err}`);
         return;
@@ -39,7 +38,7 @@ BigQuery.prototype.insertInto = function(tableName, rows, options) {
         });
       } else {
         // Insert into partitioned table
-        me.table(tablePartition, function(err, table) {
+        this.table(tablePartition, function(err, table) {
           if (err) {
             console.log(`Sorry! We've got an error while fetching the table ${tablePartition}.\nERROR: ${err}`);
             return;

--- a/bigquery.js
+++ b/bigquery.js
@@ -26,7 +26,7 @@ BigQuery.prototype.insertInto = function(tableName, rows, options) {
         return;
       }
       var isPartitioned = BigQuery.isPartitioned(table);
-      var tablePartition = isPartitioned ? BigQuery.partition(row, table) : undefined;
+      var tablePartition = isPartitioned ? BigQuery.partitionName(row, table) : undefined;
       // Insert if table is not partitioned or partition column is not defined
       if (!isPartitioned || tablePartition === undefined) {
         table.insert(row, (options || {}), function(err, insertErrors, apiResponse) {
@@ -67,7 +67,7 @@ BigQuery.prototype.table = function(tableName, callback) {
   });
 };
 
-BigQuery.partition = function(row, table) {
+BigQuery.partitionName = function(row, table) {
   var schema = table.metadata.schema.fields;
   var timestampFields = schema.filter((field) => {
     return field.type == 'TIMESTAMP' && field.name != 'root_tstamp';

--- a/bigquery.js
+++ b/bigquery.js
@@ -9,7 +9,7 @@ const config = {
 
 const ds = 'atomic';
 
-const PARTITION_FIELDS = ['updated_at', 'created_at', 'fired_at', 'ts'];
+const PARTITION_FIELDS = process.env['PARTITION_FIELDS'].split(',');
 
 var BigQuery = function() {
   this.conn = BigQueryClient(config);

--- a/bigquery.js
+++ b/bigquery.js
@@ -37,7 +37,7 @@ BigQuery.prototype.insertInto = function(tableName, rows, options) {
             return console.log('Error while inserting data: %s', err);
           }
           console.log('Response of insert into %s, %s', table['id'], JSON.stringify(apiResponse, null, 2));
-          console.log('Inserted %d row(s)', rows.length);
+          console.log('Inserted 1 row.');
         });
       } else {
         // Insert into partitioned table
@@ -51,7 +51,7 @@ BigQuery.prototype.insertInto = function(tableName, rows, options) {
               return console.log('Error while inserting data: %s', err);
             }
             console.log('Response of insert into %s, %s', table['id'], JSON.stringify(apiResponse, null, 2));
-            console.log('Inserted %d row(s)', rows.length);
+            console.log('Inserted 1 row.');
           });
         });
 

--- a/bigquery.js
+++ b/bigquery.js
@@ -1,5 +1,6 @@
 'use strict';
 var BigQueryClient = require('google-cloud/node_modules/@google-cloud/bigquery');
+var extend = require('util')._extend;
 
 const projectData = require('./auth.json');
 

--- a/bigquery.js
+++ b/bigquery.js
@@ -20,7 +20,7 @@ BigQuery.prototype.insertInto = function(tableName, rows, options) {
   // and insert in the right partition whenever the table is partitioned
   rows.forEach((row) => {
     // First, we get the table object with all available information
-    this.table(tableName, function(err, table) {
+    this.table(tableName, (err, table) => {
       if (err) {
         console.log(`Sorry! We've got an error while fetching the table ${tableName}.\nERROR: ${err}`);
         return;
@@ -38,7 +38,7 @@ BigQuery.prototype.insertInto = function(tableName, rows, options) {
         });
       } else {
         // Insert into partitioned table
-        this.table(tablePartition, function(err, table) {
+        this.table(tablePartition, (err, table) => {
           if (err) {
             console.log(`Sorry! We've got an error while fetching the table ${tablePartition}.\nERROR: ${err}`);
             return;

--- a/bigquery.js
+++ b/bigquery.js
@@ -75,7 +75,6 @@ BigQuery.partitionName = function(row, table) {
 
   var partitionField = PARTITION_FIELDS.find((field) => {
     return timestampFields.indexOf(field) > 0;
-
   })
 
   if (partitionField) {

--- a/bigquery.js
+++ b/bigquery.js
@@ -79,7 +79,7 @@ BigQuery.partitionName = function(row, table) {
 
   if (partitionField) {
     var partitionDate = row[partitionField].substring(0, 10).replace(/\-/g, '');
-    return [BigQuery.tableName(table), partitionDate].join('$')
+    return [BigQuery.tableName(table), partitionDate].join('$');
   }
 
   return BigQuery.tableName(table);

--- a/db.js
+++ b/db.js
@@ -26,7 +26,7 @@ DataBase.prototype.insertInto = function(tableName, rows, options) {
       }
       // Insert if table is not partitioned
       if (!DataBase.isPartitioned(table)) {
-        table.insert(row, options, function(err, insertErrors, apiResponse) {
+        table.insert(row, (options || {}), function(err, insertErrors, apiResponse) {
           if (err) {
             return console.log('Error while inserting data: %s', err);
           }
@@ -44,7 +44,7 @@ DataBase.prototype.insertInto = function(tableName, rows, options) {
             console.log(`Sorry! We've got an error while fetching the table ${tablePartition}.\nERROR: ${err}`);
             return;
           }
-          table.insert(row, options, function(err, insertErrors, apiResponse) {
+          table.insert(row, options || {}, function(err, insertErrors, apiResponse) {
             if (err) {
               return console.log('Error while inserting data: %s', err);
             }

--- a/db.js
+++ b/db.js
@@ -48,4 +48,8 @@ DataBase.tableName = (table) => {
   return table['metadata']['tableReference']['tableId'];
 }
 
+DataBase.isPartitioned = (table) => {
+  return table['metadata']['timePartitioning'] !== undefined;
+}
+
 module.exports = DataBase;

--- a/db.js
+++ b/db.js
@@ -14,6 +14,8 @@ var DataBase = function() {
 };
 
 DataBase.prototype.insertInto = function(table, rows, options) {
+  //Here I should get the table based on name
+  // and insert in the right partition whenever the table is partitioned
   table.insert(rows, (options || {}), function (err, insertErrors, apiResponse) {
     if (err) {
       return console.log('Error while inserting data: %s', err);

--- a/db.js
+++ b/db.js
@@ -16,9 +16,10 @@ var DataBase = function() {
 DataBase.prototype.insertInto = function(tableName, rows, options) {
   //Here I should get the table based on name
   // and insert in the right partition whenever the table is partitioned
+  var me = this;
   rows.forEach((row) => {
     // First, we get the table object with all available information
-    this.table(tableName, function(err, table) {
+    me.table(tableName, function(err, table) {
       if (err) {
         console.log(`Sorry! We've got an error while fetching the table ${tableName}.\nERROR: ${err}`);
         return;
@@ -38,7 +39,7 @@ DataBase.prototype.insertInto = function(tableName, rows, options) {
         var tablePartition = [tableName, partition].join('$');
 
         // Insert into partitioned table
-        this.table(tablePartition, function(err, table) {
+        me.table(tablePartition, function(err, table) {
           if (err) {
             console.log(`Sorry! We've got an error while fetching the table ${tablePartition}.\nERROR: ${err}`);
             return;

--- a/db.js
+++ b/db.js
@@ -44,4 +44,8 @@ DataBase.toTableName = (schemaName) => {
   ].join('_').replace(/(\.)/gi, '_').toUnderscore();
 };
 
+DataBase.tableName = (table) => {
+  return table['metadata']['tableReference']['tableId'];
+}
+
 module.exports = DataBase;

--- a/db.js
+++ b/db.js
@@ -78,12 +78,8 @@ DataBase.partition = function(row, table) {
   return;
 };
 
-DataBase.tableName = (table) => {
-  return table['metadata']['tableReference']['tableId'];
-}
+DataBase.tableName = (table) => table['metadata']['tableReference']['tableId'];
 
-DataBase.isPartitioned = (table) => {
-  return table['metadata']['timePartitioning'] !== undefined;
-}
+DataBase.isPartitioned = (table) => table['metadata']['timePartitioning'] !== undefined;
 
 module.exports = DataBase;

--- a/db.js
+++ b/db.js
@@ -35,8 +35,8 @@ DataBase.prototype.insertInto = function(tableName, rows, options) {
         });
       } else {
         // Look for the right partition
-        var partition = DataBase.partition(table, row);
-        var tablePartition = [tableName, partition].join('$');
+        var partition = DataBase.partition(row, table);
+        var tablePartition = partition ? [tableName, partition].join('$') : tableName;
 
         // Insert into partitioned table
         me.table(tablePartition, function(err, table) {

--- a/db.js
+++ b/db.js
@@ -14,8 +14,6 @@ var DataBase = function() {
 };
 
 DataBase.prototype.insertInto = function(table, rows, options) {
-  var table = this.conn.dataset(ds).table(table);
-
   table.insert(rows, (options || {}), function (err, insertErrors, apiResponse) {
     if (err) {
       return console.log('Error while inserting data: %s', err);
@@ -25,14 +23,24 @@ DataBase.prototype.insertInto = function(table, rows, options) {
   });
 }
 
-DataBase.prototype.tables = function(callback) {
+DataBase.prototype.table = function(tableName, callback) {
   var dataset = this.conn.dataset(ds);
-  dataset.getTables(function (err, tables) {
+  dataset.table(tableName).get(function (err, table, apiResponse) {
     if (err) {
       return callback(err);
     }
-    return callback(tables);
+    return callback(null, table);
   });
+};
+
+DataBase.partition = function(row, table){
+  var partitioning = table['metadata']['timePartitioning'];
+
+  if(partitioning !== undefined && partitioning['field'] !== undefined) {
+    return row[partitioning['field']].substring(0,10).replace(/\-/g, '');
+  }
+
+  return;
 };
 
 DataBase.toTableName = (schemaName) => {

--- a/db.js
+++ b/db.js
@@ -31,12 +31,7 @@ DataBase.prototype.tables = function(callback) {
     if (err) {
       return callback(err);
     }
-
-    return callback(tables.map((d) => {
-      return d['metadata']['id']
-                .replace(config.projectId + ':', '')
-                .replace(ds + '.', '');
-    }));
+    return callback(tables);
   });
 };
 

--- a/db.js
+++ b/db.js
@@ -45,15 +45,6 @@ DataBase.partition = function(row, table){
   return;
 };
 
-DataBase.toTableName = (schemaName) => {
-  const schemaInfo = schemaName.replace('iglu:', '').split('/');
-  return [
-    schemaInfo[0],
-    schemaInfo[1],
-    schemaInfo[3].split('-')[0]
-  ].join('_').replace(/(\.)/gi, '_').toUnderscore();
-};
-
 DataBase.tableName = (table) => {
   return table['metadata']['tableReference']['tableId'];
 }

--- a/extend.js
+++ b/extend.js
@@ -1,5 +1,14 @@
 String.prototype.toUnderscore = function(){
-	return this.replace(/([^_])([A-Z])/g, "$1_$2").toLowerCase();
+  return this.replace(/([^_])([A-Z])/g, "$1_$2").toLowerCase();
+};
+
+String.prototype.toTableName = function(){
+  const schemaInfo = this.replace('iglu:', '').split('/');
+  return [
+    schemaInfo[0],
+    schemaInfo[1],
+    schemaInfo[3].split('-')[0]
+  ].join('_').replace(/(\.)/gi, '_').toUnderscore();
 };
 
 Object.defineProperty(

--- a/formatter.js
+++ b/formatter.js
@@ -67,6 +67,18 @@ Formatter.contexts = (evt) => {
   return result;
 };
 
+Formatter.nestedEvents = (contexts, data) => {
+  Object.keys(contexts).forEach((c) => {
+    var key = c.toTableName();
+
+    if(data[key] === undefined) {
+      data[key] = [];
+    }
+
+    data[key].push(contexts[c]);
+  });
+}
+
 Formatter.sanitize = (value) => {
   if(value === "")
     return null;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ exports.handler = (event, context, callback) => {
   event.Records.forEach((record) => {
     const payload = new Buffer(record.kinesis.data, 'base64').toString();
     const event = Parser.event(payload),
-      contexts = Parser.contexts(event),
+      contexts = Parser.contexts(event);
 
       Parser.nestedEvents(contexts, nestedData);
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 var DataBase = require('./db.js');
 var Formatter = require('./formatter.js');
 
-require('./extend.js');
-
 var db = new DataBase();
 
 exports.handler = (event, context, callback) => {

--- a/index.js
+++ b/index.js
@@ -12,19 +12,9 @@ exports.handler = (event, context, callback) => {
   event.Records.forEach((record) => {
     const payload = new Buffer(record.kinesis.data, 'base64').toString();
     const event = Formatter.event(payload),
-          contexts = Formatter.contexts(event);
+          contexts = Formatter.contexts(event),
 
-    // This logic should be removed from here to the
-    // parser
-    Object.keys(contexts).forEach((c) => {
-      var key = DataBase.toTableName(c);
-
-      if(nestedData[key] === undefined) {
-        nestedData[key] = [];
-      }
-
-      nestedData[key].push(contexts[c]);
-    });
+    Formatter.nestedEvents(contexts, nestedData);
 
     events.push(event);
   });

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var DataBase = require('./db.js');
-var Formatter = require('./formatter.js');
+var Parser = require('./parser.js');
 
 var db = new DataBase();
 
@@ -9,10 +9,10 @@ exports.handler = (event, context, callback) => {
 
   event.Records.forEach((record) => {
     const payload = new Buffer(record.kinesis.data, 'base64').toString();
-    const event = Formatter.event(payload),
-      contexts = Formatter.contexts(event),
+    const event = Parser.event(payload),
+      contexts = Parser.contexts(event),
 
-      Formatter.nestedEvents(contexts, nestedData);
+      Parser.nestedEvents(contexts, nestedData);
 
     events.push(event);
   });

--- a/index.js
+++ b/index.js
@@ -31,12 +31,13 @@ exports.handler = (event, context, callback) => {
 
   db.tables(function(tables) {
     Object.keys(nestedData).forEach((table) => {
+      var tableName = DataBase.tableName(table);
       if(tables.indexOf(table) === -1) {
-        console.log('Table %s not found into database', table);
+        console.log('Table %s not found into database', tableName);
         return;
       }
 
-      db.insertInto(table, nestedData[table]);
+      db.insertInto(tableName, nestedData[tableName]);
     });
   });
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ exports.handler = (event, context, callback) => {
     const event = Formatter.event(payload),
           contexts = Formatter.contexts(event);
 
+    // This logic should be removed from here to the
+    // parser
     Object.keys(contexts).forEach((c) => {
       var key = DataBase.toTableName(c);
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var DataBase = require('./db.js');
+var BigQuery = require('./bigquery.js');
 var Parser = require('./parser.js');
 
-var db = new DataBase();
+var bq = new BigQuery();
 
 exports.handler = (event, context, callback) => {
   var events = [],
@@ -17,10 +17,10 @@ exports.handler = (event, context, callback) => {
     events.push(event);
   });
 
-  db.insertInto('events', events, { raw: true });
+  bq.insertInto('events', events, { raw: true });
 
   Object.keys(nestedData).forEach((tableName) => {
-    db.insertInto(tableName, nestedData[tableName]);
+    bq.insertInto(tableName, nestedData[tableName]);
   });
 
   callback(null, `Successfully processed ${event.Records.length} records.`);

--- a/parser.js
+++ b/parser.js
@@ -1,20 +1,20 @@
 require('./fields.js');
 var extend = require('util')._extend;
 
-var Formatter = function() {
+var Parser = function() {
 
 };
 
-Formatter.event = (rawData) => {
+Parser.event = (rawData) => {
   var content = rawData.split('\t'),
       result = {};
   var counter = 0;
 
   FIELDS.forEach((f) => {
     if(typeof(f) === 'object') {
-      result[f['field']] = Formatter.sanitize(f['transform'](content[counter ++]));
+      result[f['field']] = Parser.sanitize(f['transform'](content[counter ++]));
     } else {
-      result[f] = Formatter.sanitize(content[counter ++]);
+      result[f] = Parser.sanitize(content[counter ++]);
     }
   });
 
@@ -24,7 +24,7 @@ Formatter.event = (rawData) => {
   };
 };
 
-Formatter.contexts = (evt) => {
+Parser.contexts = (evt) => {
   var evtPayload = evt['json'];
   var contexts = JSON.parse(evtPayload['contexts']);
   var subtables = contexts != null ? contexts['data'] : [];
@@ -67,7 +67,7 @@ Formatter.contexts = (evt) => {
   return result;
 };
 
-Formatter.nestedEvents = (contexts, data) => {
+Parser.nestedEvents = (contexts, data) => {
   Object.keys(contexts).forEach((c) => {
     var key = c.toTableName();
 
@@ -79,11 +79,11 @@ Formatter.nestedEvents = (contexts, data) => {
   });
 }
 
-Formatter.sanitize = (value) => {
+Parser.sanitize = (value) => {
   if(value === "")
     return null;
 
   return value;
 };
 
-module.exports = Formatter;
+module.exports = Parser;

--- a/parser.js
+++ b/parser.js
@@ -1,4 +1,5 @@
 require('./fields.js');
+require('./extend.js');
 var extend = require('util')._extend;
 
 var Parser = function() {
@@ -77,7 +78,7 @@ Parser.nestedEvents = (contexts, data) => {
 
     data[key].push(contexts[c]);
   });
-}
+};
 
 Parser.sanitize = (value) => {
   if(value === "")


### PR DESCRIPTION
_This description will be changed alongside the progress of the work_.
The goal of this Pull Request is refactor this loader is a way that, whenever a BigQuery table is partitioned, the data will be inserted in the most suitable partition. This is specially interesting when historical data is sent to BigQuery through this loader.
Below are listed some steps to achieve the goal of this Pull Request (and, as a work in progress, it can change/should increase as time goes):
 - [x] Return `Table` object instead of table's name in `DataBase.prototype.tables` method;
 - [x] Create a method to get the table's name from `Table` object;
 - [x] Create a method to check whether a `Table` is partitioned or not;
 - [x] Refactor `DataBase.prototype.insertInto` method, such that ~it is possible to pass the partition as a parameter.~ it inserts data in the right partition whenever the table is partitioned.